### PR TITLE
Track selection events

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ Customize this extension via the bpmnJSTracking config:
 | `canvas.palette.click` <br> `canvas.palette.dragstart`| <ul><li>name</li><li>data-action</li><li>selection</li></ul>|
 | `canvas.popupMenu.click` | <ul><li>name</li><li>data-id</li><li>selection</li></ul>|
 
+### Diagram events
+
+| Event Name | Structure |
+| :--- | :--- |
+| `diagram.select`| <ul><li>name</li><li>oldSelection</li><li>newSelection</li></ul>|

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ import BpmnJSTracking from 'src/BpmnJSTracking';
 import trackingModules from 'src/trackingModules';
 
 export default {
-  __init__: [
-    'bpmnJSTracking',
-    'trackingModules'
+  __depends__: [
+    trackingModules
   ],
-  bpmnJSTracking: [ 'type', BpmnJSTracking ],
-  trackingModules: [ 'type', trackingModules ]
+  __init__: [
+    'bpmnJSTracking'
+  ],
+  bpmnJSTracking: [ 'type', BpmnJSTracking ]
 };

--- a/src/trackingModules/SelectionTracking.js
+++ b/src/trackingModules/SelectionTracking.js
@@ -1,0 +1,20 @@
+export default class SelectionTracking {
+  constructor(eventBus, bpmnJSTracking) {
+    this._eventBus = eventBus;
+    this._bpmnJSTracking = bpmnJSTracking;
+
+    this._eventBus.on('selection.changed', this.trackEvent.bind(this));
+  }
+
+  trackEvent(event) {
+    const payload = {
+      oldSelection: event.oldSelection,
+      newSelection: event.newSelection,
+      name: 'diagram.select'
+    };
+
+    this._bpmnJSTracking.track(payload);
+  }
+}
+
+SelectionTracking.$inject = [ 'eventBus','bpmnJSTracking' ];

--- a/src/trackingModules/index.js
+++ b/src/trackingModules/index.js
@@ -1,1 +1,11 @@
-export { default } from 'src/trackingModules/CanvasTracking';
+import CanvasTracking from './CanvasTracking';
+import SelectionTracking from './SelectionTracking';
+
+export default {
+  __init__: [
+    'canvasTracking',
+    'selectionTracking'
+  ],
+  canvasTracking: [ 'type', CanvasTracking ],
+  selectionTracking: [ 'type', SelectionTracking ]
+};

--- a/test/spec/BpmnJSTracking.spec.js
+++ b/test/spec/BpmnJSTracking.spec.js
@@ -28,6 +28,7 @@ describe('BpmnJSTracking', function() {
 
     // given
     const trackingService = getBpmnJS().get('bpmnJSTracking');
+    trackingService.enable();
 
     // then
     expect(trackingService).to.not.be.undefined;

--- a/test/spec/trackingModules/CanvasTracking.spec.js
+++ b/test/spec/trackingModules/CanvasTracking.spec.js
@@ -8,8 +8,6 @@ import {
   query as domQuery
 } from 'min-dom';
 
-import { injectStyles } from 'test/TestHelper';
-
 import BpmnJSTracking from 'src';
 
 import { CANVAS_EVENTS } from 'src/trackingModules/CanvasTracking';
@@ -18,9 +16,6 @@ import { CANVAS_EVENTS } from 'src/trackingModules/CanvasTracking';
 describe('CanvasTracking', function() {
 
   const diagram = require('test/spec/simple.bpmn').default;
-  const trackSpy = sinon.spy();
-
-  injectStyles();
 
   beforeEach(bootstrapModeler(diagram, {
     additionalModules: [
@@ -34,11 +29,6 @@ describe('CanvasTracking', function() {
     beforeEach(function() {
       getBpmnJS().get('bpmnJSTracking').enable();
     });
-
-    afterEach(inject(function() {
-      trackSpy.resetHistory();
-    }));
-
 
     describe('palette interaction', function() {
 
@@ -82,6 +72,10 @@ describe('CanvasTracking', function() {
 
     describe('palette interaction', function() {
 
+      beforeEach(function() {
+        getBpmnJS().get('bpmnJSTracking').enable();
+      });
+
       it('click', inject(function(elementRegistry, selection, bpmnJSTracking) {
 
         // given
@@ -98,7 +92,7 @@ describe('CanvasTracking', function() {
         contextPad.click();
 
         // then
-        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.called;
 
       }));
 
@@ -119,7 +113,7 @@ describe('CanvasTracking', function() {
         contextPad.dispatchEvent(new Event('dragstart'));
 
         // then
-        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.called;
 
       }));
     });
@@ -143,7 +137,7 @@ describe('CanvasTracking', function() {
         popupMenu.click();
 
         // then
-        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.called;
 
       }));
 
@@ -163,7 +157,7 @@ describe('CanvasTracking', function() {
         popupMenu.dispatchEvent(new Event('dragstart'));
 
         // then
-        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.called;
 
       }));
 
@@ -190,9 +184,12 @@ function openContextPad(elementRegistry, selection) {
 function expectEvent(name, dataType, element) {
   return getBpmnJS().invoke(function(selection) {
     return sinon.spy(function(event) {
-      expect(event['name']).to.eql(name);
-      expect(event[dataType]).to.eql(element.getAttribute(dataType));
-      expect(event['selection']).to.eql(selection.get());
+
+      if (event['name'] === name) {
+        expect(event[dataType]).to.eql(element.getAttribute(dataType));
+        expect(event['selection']).to.eql(selection.get());
+      }
+
     });
   });
 }

--- a/test/spec/trackingModules/SelectionTracking.spec.js
+++ b/test/spec/trackingModules/SelectionTracking.spec.js
@@ -1,0 +1,51 @@
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'bpmn-js/test/helper';
+
+import BpmnJSTracking from 'src';
+
+
+describe('SelectionTracking', function() {
+
+  const diagram = require('test/spec/simple.bpmn').default;
+  let bpmnJSTracking;
+
+  beforeEach(bootstrapModeler(diagram, {
+    additionalModules: [
+      BpmnJSTracking
+    ]
+  }));
+
+  beforeEach(function() {
+    bpmnJSTracking = getBpmnJS().get('bpmnJSTracking');
+  });
+
+  beforeEach(inject(function(bpmnJSTracking) {
+    bpmnJSTracking.enable();
+  }));
+
+
+  it('should track selection', inject(function(elementRegistry, selection) {
+
+    // given
+    const newSelection = elementRegistry.get('StartEvent_1');
+
+    const spy = sinon.spy(function(event) {
+      expect(event.name).to.eql('diagram.select');
+      expect(event.newSelection).to.eql([ newSelection ]);
+      expect(event.oldSelection).to.eql([]);
+    });
+
+    bpmnJSTracking.on('tracking.event', spy);
+
+    // when
+    selection.select(newSelection);
+
+    // then
+    expect(spy).to.have.been.calledOnce;
+
+  }));
+
+});


### PR DESCRIPTION
Related to #1 

The plan is to add diagram editing events in a separate handler (moving and updating elements).

Note: one of the commits was made to cleanup some tests from the previous PR