### PR TITLE
Detach event handlers from bpmnJSTracking

### DIFF
--- a/src/BpmnJSTracking.js
+++ b/src/BpmnJSTracking.js
@@ -1,21 +1,10 @@
-import trackingModules from './trackingModules';
-class BpmnJSTracking {
 
-  constructor(config, selection, eventBus, canvas) {
+export default class BpmnJSTracking {
+
+  constructor(config, eventBus) {
     this._eventBus = eventBus;
 
     this._isEnabled = false;
-
-    this.trackingModules = [];
-
-    // init tracking modules
-    trackingModules.forEach((trackingConstructor) => {
-      this.trackingModules.push(new trackingConstructor({
-        track: this.track.bind(this),
-        _selection: selection,
-        _canvas: canvas
-      }));
-    });
 
     // setup tracking if configured
     if (config && config.track)
@@ -30,10 +19,6 @@ class BpmnJSTracking {
   enable() {
     this._isEnabled = true;
 
-    this.trackingModules.forEach((module) => {
-      module.enable();
-    });
-
     this._eventBus.fire('tracking.enabled');
   }
 
@@ -45,7 +30,7 @@ class BpmnJSTracking {
 
 }
 
-BpmnJSTracking.$inject = [ 'config.bpmnJSTracking', 'selection', 'eventBus', 'canvas' ];
+BpmnJSTracking.$inject = [ 'config.bpmnJSTracking', 'eventBus' ];
 
 BpmnJSTracking.prototype.on = function(event, priority, callback, target) {
   return this._eventBus.on(event, priority, callback, target);
@@ -55,11 +40,4 @@ BpmnJSTracking.prototype.track = function(event) {
   if (this.isEnabled()) {
     this._eventBus.fire('tracking.event', event);
   }
-};
-
-export default {
-  __init__: [
-    'bpmnJSTracking'
-  ],
-  bpmnJSTracking: [ 'type', BpmnJSTracking ]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 import BpmnJSTracking from 'src/BpmnJSTracking';
+import trackingModules from 'src/trackingModules';
 
 export default {
-  __init__: [ 'bpmnJSTracking' ],
-  bpmnJSTracking: [ 'type', BpmnJSTracking ]
+  __init__: [
+    'bpmnJSTracking',
+    'trackingModules'
+  ],
+  bpmnJSTracking: [ 'type', BpmnJSTracking ],
+  trackingModules: [ 'type', trackingModules ]
 };

--- a/src/trackingModules/CanvasTracking.js
+++ b/src/trackingModules/CanvasTracking.js
@@ -14,11 +14,12 @@ export const CANVAS_EVENTS = {
 };
 
 export default class CanvasTracking {
-  constructor(props) {
-    this._selection = props._selection;
-    this._canvas = props._canvas;
+  constructor(selection, canvas, eventBus, bpmnJSTracking) {
+    this._selection = selection;
+    this._canvas = canvas;
+    this._bpmnJSTracking = bpmnJSTracking;
 
-    this.track = props.track;
+    this.addEventListeners(this._canvas);
   }
 
   trackEvent(event) {
@@ -36,23 +37,19 @@ export default class CanvasTracking {
         payload[`${dataType}`] = element.getAttribute(dataType);
         payload['selection'] = this._selection.get();
 
-        this.track(payload);
+        this._bpmnJSTracking.track(payload);
       }
     });
   }
 
-  enable() {
-    const diagramContainer = this._canvas.getContainer();
-
+  addEventListeners(canvas) {
+    const diagramContainer = canvas.getContainer();
     diagramContainer.addEventListener('click', this.trackEvent.bind(this), true);
     diagramContainer.addEventListener('dragstart', this.trackEvent.bind(this), true);
   }
-
-  disable() {
-    document.body.removeEventListener('click', this.trackEvent, true);
-  }
 }
 
+CanvasTracking.$inject = [ 'selection', 'canvas', 'eventBus','bpmnJSTracking' ];
 
 // helpers ///////////////////////////////
 

--- a/src/trackingModules/index.js
+++ b/src/trackingModules/index.js
@@ -1,5 +1,1 @@
-import CanvasTracking from 'src/trackingModules/CanvasTracking';
-
-export default [
-  CanvasTracking
-];
+export { default } from 'src/trackingModules/CanvasTracking';

--- a/test/spec/BpmnJSTracking.spec.js
+++ b/test/spec/BpmnJSTracking.spec.js
@@ -6,7 +6,7 @@ import {
 
 import { injectStyles } from '../TestHelper';
 
-import BpmnJSTracking from '../../src/BpmnJSTracking';
+import BpmnJSTracking from 'src';
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START;
 

--- a/test/spec/trackingModules/CanvasTracking.spec.js
+++ b/test/spec/trackingModules/CanvasTracking.spec.js
@@ -10,7 +10,7 @@ import {
 
 import { injectStyles } from 'test/TestHelper';
 
-import BpmnJSTracking from 'src/BpmnJSTracking';
+import BpmnJSTracking from 'src';
 
 import { CANVAS_EVENTS } from 'src/trackingModules/CanvasTracking';
 
@@ -25,11 +25,7 @@ describe('CanvasTracking', function() {
   beforeEach(bootstrapModeler(diagram, {
     additionalModules: [
       BpmnJSTracking
-    ],
-    bpmnJSTracking: {
-      optIn: function() {},
-      optOut: function() {}
-    }
+    ]
   }));
 
 


### PR DESCRIPTION
Related to #1 and https://github.com/bpmn-io/bpmn-js-tracking/pull/3#pullrequestreview-1089766500

This way, event handlers can be plugged in easily on its own.

Module can be used by firing events with: `bpmnJSTracking.track(event)` (which will fire 'tracking.event')

and plugging into the events fired:

```javascript
bpmnJSTracking.on('tracking.event', function(event) {
  if (bpmnJSTracking.isEnabled()) {
    // add more data to payload if desired
    // send to tracking tool
  }
});
```