### PR TITLE
feat: allow to blacklist/whitelist events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ bpmnJsTracking.on('tracking.disabled', function(event) {
 });
 ```
 
+[Tracking modules](https://github.com/bpmn-io/bpmn-js-tracking/tree/main/src/trackingModules) may be whitelisted or blacklisted by passing a `whitelist`/`blacklist` option when initializing BpmnJS. If neither is provided, all modules are enabled.
+
+```javascript
+new BpmnJS({
+  additionalModules: [
+    BpmnJSTracking
+  ],
+  bpmnJsTracking: {
+    whitelist: [ 'popupMenuTracking' ]
+  }
+})
+```
+
 ## Tracked events
 
 ### Diagram events

--- a/src/trackingModules/Util.js
+++ b/src/trackingModules/Util.js
@@ -1,0 +1,16 @@
+export function isTrackingModuleEnabled(config, module) {
+
+  // if no config, is allowed
+  if (! config) {
+    return true;
+  }
+
+  // if in blacklist, module is not allowed
+  if (config.blacklist && config.blacklist.indexOf(module) !== -1) {
+    return false;
+  }
+
+  // if whitelist is not set, module is allowed
+  // if whitelist is set, module is allowed if it is in the list
+  return !config.whitelist || config.whitelist.indexOf(module) !== -1;
+}

--- a/src/trackingModules/diagram/SelectionTracking.js
+++ b/src/trackingModules/diagram/SelectionTracking.js
@@ -1,9 +1,13 @@
+import { isTrackingModuleEnabled } from '../Util';
+
 export default class SelectionTracking {
-  constructor(eventBus, bpmnJSTracking) {
+  constructor(eventBus, bpmnJSTracking, config) {
     this._eventBus = eventBus;
     this._bpmnJSTracking = bpmnJSTracking;
 
-    this._eventBus.on('selection.changed', this.trackEvent.bind(this));
+    if (isTrackingModuleEnabled(config, 'selectionTracking')) {
+      this._eventBus.on('selection.changed', this.trackEvent.bind(this));
+    }
   }
 
   trackEvent(event) {
@@ -17,4 +21,4 @@ export default class SelectionTracking {
   }
 }
 
-SelectionTracking.$inject = [ 'eventBus','bpmnJSTracking' ];
+SelectionTracking.$inject = [ 'eventBus','bpmnJSTracking', 'config.bpmnJSTracking' ];

--- a/test/spec/trackingModules/Util.spec.js
+++ b/test/spec/trackingModules/Util.spec.js
@@ -1,0 +1,51 @@
+import {
+  isTrackingModuleEnabled
+} from 'src/trackingModules/Util';
+
+
+describe('Util', function() {
+
+  describe('#isTrackingModuleEnabled', function() {
+
+    it('no config', function() {
+
+      // given
+      const config = null;
+
+      // expect
+      expect(isTrackingModuleEnabled(config, 'foo')).to.be.true;
+    });
+
+
+    it('blacklist', function() {
+
+      // given
+      const config = { blacklist: [ 'foo' ] };
+
+      // expect
+      expect(isTrackingModuleEnabled(config, 'foo')).to.be.false;
+    });
+
+
+    it('whitelist - included', function() {
+
+      // given
+      const config = { whitelist: [ 'foo' ] };
+
+      // expect
+      expect(isTrackingModuleEnabled(config, 'foo')).to.be.true;
+    });
+
+
+    it('whitelist - not included', function() {
+
+      // given
+      const config = { whitelist: [ '' ] };
+
+      // expect
+      expect(isTrackingModuleEnabled(config, 'foo')).to.be.false;
+    });
+
+  });
+
+});


### PR DESCRIPTION
Related to #6 

My proposal: configure via `bpmnJSTracking` config options

```javascript
// in tracking module
if (isTrackingModuleEnabled(config, <trackingModuleName>)) {
 // track suff
}
```

See https://github.com/bpmn-io/internal-docs/issues/746#issuecomment-1504977869