### PR TITLE
Add palette tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ bpmnJsTracking.on('tracking.disabled', function(event) {
 
 ## Tracked events
 
+### Palette events
+
+| Event Name | Structure |
+| :--- | :--- |
+| `palette.trigger`| <ul><li>entryId</li><li>entryGroup</li><li>entryTitle</li><li>selection</li><li>triggerType: ["click", "drag", "keyboard"]</li></ul>|
 ### Popup menu events
 
 | Event Name | Structure |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bpmnJsTracking.on('tracking.disabled', function(event) {
 | Event Name | Structure |
 | :--- | :--- |
 | `popupMenu.open`| <ul><li>selection</li></ul>|
-| `popupMenu.trigger`| <ul><li>triggerType: ["click", "drag", "keyboard"]</li><li>entryLabel</li></ul>|
+| `popupMenu.trigger`| <ul><li>entryId</li><li>entryGroup</li><li>entryLabel</li><li>triggerType: ["click", "drag", "keyboard"]</li></ul>|
 
 ### Selection events
 

--- a/src/trackingModules/index.js
+++ b/src/trackingModules/index.js
@@ -1,8 +1,10 @@
+import palette from './palette';
 import popupMenuTracking from './popupMenu';
 import selectionTracking from './selection';
 
 export default {
   __depends__: [
+    palette,
     popupMenuTracking,
     selectionTracking
   ]

--- a/src/trackingModules/palette/PaletteTracking.js
+++ b/src/trackingModules/palette/PaletteTracking.js
@@ -1,0 +1,37 @@
+import { getEventType } from '../Util';
+
+export default class Palette {
+  constructor(eventBus, bpmnJSTracking, selection) {
+    this._eventBus = eventBus;
+    this._bpmnJSTracking = bpmnJSTracking;
+    this._selection = selection;
+
+    this._eventBus.on('palette.trigger', this.trackTrigger.bind(this));
+  }
+
+  trackTrigger(e) {
+    const { entry, event } = e;
+    const { target } = event;
+
+    const entryAction = target.getAttribute('data-action');
+
+    const type = getEventType(event);
+
+    this._bpmnJSTracking.track({
+      name: 'palette.trigger',
+      data: {
+        entryId: entryAction,
+        entryGroup: entry.group || 'default',
+        entryTitle: entry.title,
+        selection: this._selection.get(),
+        triggerType: type
+      }
+    });
+  }
+}
+
+Palette.$inject = [
+  'eventBus',
+  'bpmnJSTracking',
+  'selection'
+];

--- a/src/trackingModules/palette/index.js
+++ b/src/trackingModules/palette/index.js
@@ -1,0 +1,8 @@
+import PaletteTracking from './PaletteTracking.js';
+
+export default {
+  __init__: [
+    'paletteTracking'
+  ],
+  paletteTracking: [ 'type', PaletteTracking ]
+};

--- a/src/trackingModules/popupMenu/PopupMenuTracking.js
+++ b/src/trackingModules/popupMenu/PopupMenuTracking.js
@@ -22,11 +22,17 @@ export default class PopupMenuTracking {
   trackTrigger(e) {
     const { entry, event } = e;
 
+    const { target } = event;
+
     const type = getEventType(event);
+
+    const entryId = target.getAttribute('data-id');
 
     this._bpmnJSTracking.track({
       name: 'popupMenu.trigger',
       data: {
+        entryId,
+        entryGroup: entry.group || 'default',
         entryLabel: entry.label,
         triggerType: type
       }

--- a/src/trackingModules/selection/SelectionTracking.js
+++ b/src/trackingModules/selection/SelectionTracking.js
@@ -17,4 +17,4 @@ export default class SelectionTracking {
   }
 }
 
-SelectionTracking.$inject = [ 'eventBus','bpmnJSTracking' ];
+SelectionTracking.$inject = [ 'eventBus', 'bpmnJSTracking' ];

--- a/test/spec/trackingModules/PaletteMenuTracking.spec.js
+++ b/test/spec/trackingModules/PaletteMenuTracking.spec.js
@@ -1,0 +1,100 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+
+import { BpmnJSTracking } from 'src';
+import PopupMenuTracking from 'src/trackingModules/palette';
+
+
+describe('PaletteMenuTracking', function() {
+
+  const diagram = require('test/spec/simple.bpmn').default;
+
+  beforeEach(bootstrapModeler(diagram, {
+    additionalModules: [
+      BpmnJSTracking,
+      PopupMenuTracking
+    ]
+  }));
+
+
+  describe('should subscribe', function() {
+
+    it('popupMenu.trigger', inject(function(bpmnJSTracking, palette) {
+
+      // given
+      const spy = sinon.spy(bpmnJSTracking, 'track');
+
+      const event = getPaletteEvent('create.start-event');
+
+      // when
+      palette.trigger(null, event);
+
+      // expect
+      expect(spy).to.have.been.calledOnce;
+    }));
+
+  });
+
+
+  describe('should track', function() {
+
+    beforeEach(inject(function(bpmnJSTracking) {
+      bpmnJSTracking.enable();
+    }));
+
+    it('popup menu trigger entry', inject(function(elementRegistry, selection, bpmnJSTracking) {
+
+      // given
+      const element = elementRegistry.get('StartEvent_1');
+      selection.select(element);
+
+      const spy = sinon.spy();
+      bpmnJSTracking.on('tracking.event', spy);
+
+      // when
+      triggerPalette('create.start-event');
+
+      // then
+      expect(spy).to.have.been.called;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        name: 'palette.trigger',
+        data: {
+          entryId: 'create.start-event',
+          entryGroup: 'event',
+          entryTitle: 'Create StartEvent',
+          selection: [ element ],
+          triggerType: 'click'
+        }
+      });
+    }));
+
+  });
+
+});
+
+
+// helpers /////////
+
+function triggerPalette(entry) {
+  const target = domQuery(`.djs-palette [data-action="${entry}"]`);
+
+  target.click();
+}
+
+function getPaletteEvent(entryId) {
+  const target = domQuery(".djs-palette [data-action='" + entryId + "']");
+
+  return {
+    target: target,
+    preventDefault: function() {},
+    clientX: 100,
+    clientY: 100
+  };
+}

--- a/test/spec/trackingModules/PopupMenuTracking.spec.js
+++ b/test/spec/trackingModules/PopupMenuTracking.spec.js
@@ -97,8 +97,10 @@ describe('PopupMenuTracking', function() {
       selection.select(shape);
 
       const spy = sinon.spy(function(event) {
-        if (event === 'popupMenu.trigger') {
+        if (event.name === 'popupMenu.trigger') {
           const { data } = event;
+          expect(data.entryId).to.eql('replace-with-none-intermediate-throwing');
+          expect(data.entryGroup).to.eql('default');
           expect(data.entryLabel).to.eql('Intermediate Throw Event');
           expect(data.triggerType).to.eql('click');
         }


### PR DESCRIPTION
Closes #7 

I also noticed some attributes I added for `palette` were missing for `popupMenu`, so I added it with https://github.com/bpmn-io/bpmn-js-tracking/commit/c9e820aedcd3df32c10517b78eb4ca37fbafb6a3. Happy to extract this into another PR if it's easier.