### PR TITLE
feat: add modeling events

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ bpmnJsTracking.on('tracking.disabled', function(event) {
 | :--- | :--- |
 | `contextPad.trigger`| <ul><li>entryId</li><li>entryGroup</li><li>entryTitle</li><li>selection</li><li>triggerType: ["click", "drag", "keyboard"]</li></ul>|
 
+### Modeling events
+
+| Event Name | Structure |
+| :--- | :--- |
+| `modeling.appendElement`| <ul><li>element</li><li>sourceElement</li></ul>|
+| `modeling.createElements`| <ul><li>elements</li></ul>|
+| `modeling.replaceElement`| <ul><li>oldElement</li><li>newElement</li></ul>|
+
 ### Palette events
 
 | Event Name | Structure |

--- a/src/trackingModules/index.js
+++ b/src/trackingModules/index.js
@@ -1,4 +1,5 @@
 import contextPadTracking from './contextPad';
+import modelingTracking from './modeling';
 import paletteTracking from './palette';
 import popupMenuTracking from './popupMenu';
 import selectionTracking from './selection';
@@ -6,6 +7,7 @@ import selectionTracking from './selection';
 export default {
   __depends__: [
     contextPadTracking,
+    modelingTracking,
     paletteTracking,
     popupMenuTracking,
     selectionTracking

--- a/src/trackingModules/modeling/ModelingTracking.js
+++ b/src/trackingModules/modeling/ModelingTracking.js
@@ -1,0 +1,65 @@
+export default class ModelingTracking {
+  constructor(eventBus, bpmnJSTracking, elementRegistry, selection) {
+    this._eventBus = eventBus;
+    this._bpmnJSTracking = bpmnJSTracking;
+    this._elementRegistry = elementRegistry;
+    this._selection = selection;
+
+    this._eventBus.on(
+      'commandStack.elements.create.postExecuted',
+      this.trackElementsCreate.bind(this)
+    );
+
+    this._eventBus.on(
+      'commandStack.shape.append.postExecuted',
+      this.trackElementAppend.bind(this)
+    );
+
+    this._eventBus.on(
+      'commandStack.shape.replace.postExecuted',
+      this.trackElementReplace.bind(this)
+    );
+  }
+
+  trackElementsCreate(e) {
+    const { context } = e;
+
+    this._bpmnJSTracking.track({
+      name: 'modeling.createElements',
+      data: {
+        elements: context.elements
+      }
+    });
+  }
+
+  trackElementAppend(e) {
+    const { shape, source } = e.context;
+
+    this._bpmnJSTracking.track({
+      name: 'modeling.appendElement',
+      data: {
+        element: shape,
+        sourceElement: source
+      }
+    });
+  }
+
+  trackElementReplace(e) {
+    const { oldShape, newShape } = e.context;
+
+    this._bpmnJSTracking.track({
+      name: 'modeling.replaceElement',
+      data: {
+        newElement: newShape,
+        oldElement: oldShape
+      }
+    });
+  }
+}
+
+ModelingTracking.$inject = [
+  'eventBus',
+  'bpmnJSTracking',
+  'elementRegistry',
+  'selection'
+];

--- a/src/trackingModules/modeling/index.js
+++ b/src/trackingModules/modeling/index.js
@@ -1,0 +1,8 @@
+import ModelingTracking from './ModelingTracking.js';
+
+export default {
+  __init__: [
+    'modelingTracking'
+  ],
+  modelingTracking: [ 'type', ModelingTracking ]
+};

--- a/test/spec/trackingModules/ModelingTracking.spec.js
+++ b/test/spec/trackingModules/ModelingTracking.spec.js
@@ -1,0 +1,167 @@
+import {
+  bootstrapModeler,
+  inject,
+  getBpmnJS
+} from 'test/TestHelper';
+
+import { BpmnJSTracking } from 'src';
+import ModelingTracking from 'src/trackingModules/modeling';
+
+
+describe('ModelingTracking', function() {
+
+  const diagram = require('test/spec/simple.bpmn').default;
+
+  beforeEach(bootstrapModeler(diagram, {
+    additionalModules: [
+      BpmnJSTracking,
+      ModelingTracking
+    ]
+  }));
+
+
+  describe('should subscribe', function() {
+
+    it('commandStack.shape.create.postExecuted', inject(function(bpmnJSTracking, modeling, canvas) {
+
+      // given
+      const spy = sinon.spy(bpmnJSTracking, 'track');
+
+      // when
+      createElements();
+
+      // expect
+      expect(spy).to.have.been.calledOnce;
+    }));
+
+
+    it('commandStack.shape.append.postExecuted', inject(function(bpmnJSTracking, elementRegistry) {
+
+      // given
+      const spy = sinon.spy(bpmnJSTracking, 'track');
+      const shape = elementRegistry.get('StartEvent_1');
+
+      // when
+      appendShape(shape);
+
+      // expect
+      expect(spy).to.have.been.calledOnce;
+    }));
+
+
+    it('commandStack.shape.replace.postExecuted', inject(function(bpmnJSTracking, elementRegistry) {
+
+      // given
+      const spy = sinon.spy(bpmnJSTracking, 'track');
+
+      const oldShape = elementRegistry.get('StartEvent_1');
+
+      replaceShape(oldShape);
+
+      // expect
+      expect(spy).to.have.been.calledOnce;
+    }));
+
+  });
+
+
+  describe('should track', function() {
+
+    beforeEach(inject(function(bpmnJSTracking) {
+      bpmnJSTracking.enable();
+    }));
+
+    it('element created', inject(function(bpmnJSTracking) {
+
+      // given
+      const spy = sinon.spy();
+      bpmnJSTracking.on('tracking.event', spy);
+
+      // when
+      const elements = createElements();
+
+      // then
+      expect(spy).to.have.been.called;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        name: 'modeling.createElements',
+        data: {
+          elements
+        }
+      });
+    }));
+
+
+    it('element appended', inject(function(bpmnJSTracking, elementRegistry) {
+
+      // given
+      const spy = sinon.spy();
+      const source = elementRegistry.get('StartEvent_1');
+
+      bpmnJSTracking.on('tracking.event', spy);
+
+      // when
+      const appendedElement = appendShape(source);
+
+      // then
+      expect(spy).to.have.been.called;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        name: 'modeling.appendElement',
+        data: {
+          sourceElement: source,
+          element: appendedElement
+        }
+      });
+    }));
+
+
+    it('element replaced', inject(function(bpmnJSTracking, elementRegistry) {
+
+      // given
+      const spy = sinon.spy();
+      const oldElement = elementRegistry.get('StartEvent_1');
+
+      bpmnJSTracking.on('tracking.event', spy);
+
+      // when
+      const newElement = replaceShape(oldElement);
+
+      // then
+      expect(spy).to.have.been.called;
+      expect(spy.getCalls()[0].args[1]).to.eql({
+        name: 'modeling.replaceElement',
+        data: {
+          oldElement,
+          newElement
+        }
+      });
+    }));
+
+  });
+
+});
+
+
+// helpers /////////
+
+function createElements() {
+  const modeling = getBpmnJS().get('modeling');
+  const canvas = getBpmnJS().get('canvas');
+
+  return modeling.createElements(
+    { type: 'bpmn:Task' },
+    { x: 0, y: 0 },
+    canvas.getRootElement()
+  );
+}
+
+function appendShape(source) {
+  const modeling = getBpmnJS().get('modeling');
+
+  return modeling.appendShape(source, { type: 'bpmn:Task' });
+}
+
+function replaceShape(shape) {
+  const replace = getBpmnJS().get('bpmnReplace');
+
+  return replace.replaceElement(shape, { type: 'bpmn:EndEvent' });
+}


### PR DESCRIPTION
Closes #16

Listens to `shape.append`, `shape.replace`, `elements.create`.

I decided to listen to `elements.create` instead of `shape.create` because (_from my understanding_), `shape.create` will be also fired when an element is appended or replaced. In order to prevent unnecessary redundancy, I decided that isolating the pure "create" action would be more useful now.

But I welcome opinions on this (cc @christian-konrad in case this detail interests you).