### PR TITLE
fix: include element templates tracking in `BpmnJSTrackingModules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@bpmn-io/bpmn-js-tracking](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.3.1
+
+* `FIX`: include `elementTemplatesTracking` module in `BpmnJSTrackingModules` ([#33](https://github.com/bpmn-io/bpmn-js-tracking/pull/33))
+
 ## 0.3.0
 
 * `FEAT`: handle invalid events ([#27](https://github.com/bpmn-io/bpmn-js-tracking/pull/27))

--- a/lib/features/index.js
+++ b/lib/features/index.js
@@ -1,4 +1,5 @@
 import contextPadTracking from './context-pad';
+import elementTemplates from './element-templates';
 import modelingTracking from './modeling';
 import paletteTracking from './palette';
 import popupMenuTracking from './popup-menu';
@@ -7,6 +8,7 @@ import selectionTracking from './selection';
 export default {
   __depends__: [
     contextPadTracking,
+    elementTemplates,
     modelingTracking,
     paletteTracking,
     popupMenuTracking,

--- a/test/spec/features/ElementTemplatesTracking.bpmn
+++ b/test/spec/features/ElementTemplatesTracking.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1r85mmt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_0a8lsga" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="StartEvent" />
+    <bpmn:startEvent id="StartEvent_2" name="StartEvent template" zeebe:modelerTemplate="default" zeebe:modelerTemplateVersion="1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0a8lsga">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="171" y="122" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0uytmsy_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="179" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="195" width="52" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/ElementTemplatesTracking.spec.js
+++ b/test/spec/features/ElementTemplatesTracking.spec.js
@@ -27,7 +27,7 @@ import {
 
 describe('ElementTemplatesTracking', function() {
 
-  const diagramXML = require('../simple.bpmn').default;
+  const diagramXML = require('./ElementTemplatesTracking.bpmn').default;
 
   beforeEach(bootstrapPropertiesPanel(diagramXML, {
     additionalModules: [

--- a/test/spec/simple.bpmn
+++ b/test/spec/simple.bpmn
@@ -2,15 +2,11 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1r85mmt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_0a8lsga" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" />
-    <bpmn:startEvent id="StartEvent_2" zeebe:modelerTemplate="default" zeebe:modelerTemplateVersion="1"/>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0a8lsga">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="79" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0uytmsy_di" bpmnElement="StartEvent_2">
-        <dc:Bounds x="179" y="152" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
`elementTemplatesTracking` wasn't being exported with `BpmnJSTrackingModules` 🙈