### PR TITLE
chore: clean up tests

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -14,6 +14,24 @@ import TestContainer from 'mocha-test-container-support';
 
 let PROPERTIES_PANEL_CONTAINER;
 
+global.chai.use(function(chai, utils) {
+
+  utils.addMethod(chai.Assertion.prototype, 'jsonEqual', function(comparison) {
+
+    var actual = JSON.stringify(this._obj);
+    var expected = JSON.stringify(comparison);
+
+    this.assert(
+      actual == expected,
+      'expected #{this} to deep equal #{act}',
+      'expected #{this} not to deep equal #{act}',
+      comparison, // expected
+      this._obj, // actual
+      true // show diff
+    );
+  });
+});
+
 export function injectStyles() {
 
   insertCSS(

--- a/test/spec/features/ContextPadTracking.spec.js
+++ b/test/spec/features/ContextPadTracking.spec.js
@@ -58,7 +58,7 @@ describe('ContextPadTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        compareEvents(event, {
+        expect(event).to.jsonEqual({
           name: 'contextPad.trigger',
           data: {
             entryId: 'replace',
@@ -66,7 +66,8 @@ describe('ContextPadTracking', function() {
             entryTitle: 'Change type',
             selection: [ element ],
             triggerType: 'click'
-          }
+          },
+          type: 'tracking.event'
         });
       });
 
@@ -76,7 +77,7 @@ describe('ContextPadTracking', function() {
       triggerContextPad('replace');
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
     }));
 
 
@@ -87,7 +88,7 @@ describe('ContextPadTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        compareEvents(event, {
+        expect(event).to.jsonEqual({
           name: 'contextPad.trigger',
           data: {
             entryId: 'append',
@@ -95,7 +96,8 @@ describe('ContextPadTracking', function() {
             entryTitle: 'Append element',
             selection: [ element ],
             triggerType: 'click'
-          }
+          },
+          type: 'tracking.event'
         });
       });
 
@@ -106,7 +108,7 @@ describe('ContextPadTracking', function() {
       dispatchClick(icon);
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
     }));
 
   });
@@ -145,9 +147,4 @@ const dispatchClick = target => {
     cancelable: true
   });
   target.dispatchEvent(ev);
-};
-
-const compareEvents = (event, expected) => {
-  return expect(event.name).to.eql(expected.name) &&
-          expect(JSON.stringify(event.data)).to.equal(JSON.stringify(expected.data));
 };

--- a/test/spec/features/ElementTemplatesTracking.spec.js
+++ b/test/spec/features/ElementTemplatesTracking.spec.js
@@ -131,10 +131,19 @@ describe('ElementTemplatesTracking', function() {
     it('select element template', inject(async function(elementRegistry, bpmnJSTracking) {
 
       // given
-      const spy = sinon.spy();
       const element = elementRegistry.get('StartEvent_1');
 
       await selectElement(element);
+
+      const spy = sinon.spy(function(event) {
+        expect(event).to.jsonEqual({
+          name: 'elementTemplates.select',
+          data: {
+            element
+          },
+          type: 'tracking.event'
+        });
+      });
 
       bpmnJSTracking.on('tracking.event', spy);
 
@@ -143,22 +152,26 @@ describe('ElementTemplatesTracking', function() {
 
       // expect
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
-        name: 'elementTemplates.select',
-        data: {
-          element
-        }
-      });
     }));
 
 
     it('update element template', inject(async function(elementRegistry, bpmnJSTracking) {
 
       // given
-      const spy = sinon.spy();
       const element = elementRegistry.get('StartEvent_2');
 
       await selectElement(element);
+
+      const spy = sinon.spy(function(event) {
+        expect(event).to.jsonEqual({
+          name: 'elementTemplates.update',
+          data: {
+            element,
+            newTemplate: templates[1]
+          },
+          type: 'tracking.event'
+        });
+      });
 
       bpmnJSTracking.on('tracking.event', spy);
 
@@ -170,23 +183,25 @@ describe('ElementTemplatesTracking', function() {
 
       // expect
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
-        name: 'elementTemplates.update',
-        data: {
-          element,
-          newTemplate: templates[1]
-        }
-      });
     }));
 
 
     it('unlink element template', inject(async function(elementRegistry, bpmnJSTracking) {
 
       // given
-      const spy = sinon.spy();
       const element = elementRegistry.get('StartEvent_2');
 
       await selectElement(element);
+
+      const spy = sinon.spy(function(event) {
+        expect(event).to.jsonEqual({
+          name: 'elementTemplates.unlink',
+          data: {
+            element
+          },
+          type: 'tracking.event'
+        });
+      });
 
       bpmnJSTracking.on('tracking.event', spy);
 
@@ -198,22 +213,25 @@ describe('ElementTemplatesTracking', function() {
 
       // expect
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
-        name: 'elementTemplates.unlink',
-        data: {
-          element
-        }
-      });
     }));
 
 
     it('remove element template', inject(async function(elementRegistry, bpmnJSTracking) {
 
       // given
-      const spy = sinon.spy();
       const element = elementRegistry.get('StartEvent_2');
 
       await selectElement(element);
+
+      const spy = sinon.spy(function(event) {
+        expect(event).to.jsonEqual({
+          name: 'elementTemplates.remove',
+          data: {
+            element
+          },
+          type: 'tracking.event'
+        });
+      });
 
       bpmnJSTracking.on('tracking.event', spy);
 
@@ -225,12 +243,6 @@ describe('ElementTemplatesTracking', function() {
 
       // expect
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
-        name: 'elementTemplates.remove',
-        data: {
-          element
-        }
-      });
     }));
 
   });

--- a/test/spec/features/ModelingTracking.spec.js
+++ b/test/spec/features/ModelingTracking.spec.js
@@ -81,7 +81,7 @@ describe('ModelingTracking', function() {
       const elements = createElements();
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
       expect(spy.getCalls()[0].args[1]).to.eql({
         name: 'modeling.createElements',
         data: {
@@ -103,7 +103,7 @@ describe('ModelingTracking', function() {
       const appendedElement = appendShape(source);
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
       expect(spy.getCalls()[0].args[1]).to.eql({
         name: 'modeling.appendElement',
         data: {
@@ -126,7 +126,7 @@ describe('ModelingTracking', function() {
       const newElement = replaceShape(oldElement);
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
       expect(spy.getCalls()[0].args[1]).to.eql({
         name: 'modeling.replaceElement',
         data: {

--- a/test/spec/features/PaletteTracking.spec.js
+++ b/test/spec/features/PaletteTracking.spec.js
@@ -58,7 +58,7 @@ describe('PaletteMenuTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        compareEvents(event, {
+        expect(event).to.jsonEqual({
           name: 'palette.trigger',
           data: {
             entryId: 'create.start-event',
@@ -66,7 +66,8 @@ describe('PaletteMenuTracking', function() {
             entryTitle: 'Create StartEvent',
             selection: [ element ],
             triggerType: 'click'
-          }
+          },
+          type: 'tracking.event'
         });
       });
 
@@ -76,7 +77,7 @@ describe('PaletteMenuTracking', function() {
       triggerPalette('create.start-event');
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
     }));
 
 
@@ -87,7 +88,7 @@ describe('PaletteMenuTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        compareEvents(event, {
+        expect(event).to.jsonEqual({
           name: 'palette.trigger',
           data: {
             entryId: 'create',
@@ -95,7 +96,8 @@ describe('PaletteMenuTracking', function() {
             entryTitle: 'Create element',
             selection: [ element ],
             triggerType: 'click'
-          }
+          },
+          type: 'tracking.event'
         });
       });
 
@@ -106,7 +108,7 @@ describe('PaletteMenuTracking', function() {
       dispatchClick(icon);
 
       // then
-      expect(spy).to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
     }));
 
   });
@@ -140,9 +142,4 @@ const dispatchClick = target => {
     cancelable: true
   });
   target.dispatchEvent(ev);
-};
-
-const compareEvents = (event, expected) => {
-  return expect(event.name).to.eql(expected.name) &&
-          expect(JSON.stringify(event.data)).to.equal(JSON.stringify(expected.data));
 };

--- a/test/spec/features/PopupMenuTracking.spec.js
+++ b/test/spec/features/PopupMenuTracking.spec.js
@@ -74,9 +74,13 @@ describe('PopupMenuTracking', function() {
       selection.select(shape);
 
       const spy = sinon.spy(function(event) {
-        const { name, data } = event;
-        expect(name).to.eql('popupMenu.open');
-        expect(data.selection).to.eql([ shape ]);
+        expect(event).to.jsonEqual({
+          name: 'popupMenu.open',
+          data: {
+            selection: [ shape ]
+          },
+          type: 'tracking.event'
+        });
       });
 
       bpmnJSTracking.on('tracking.event', spy);
@@ -97,24 +101,26 @@ describe('PopupMenuTracking', function() {
       selection.select(shape);
 
       const spy = sinon.spy(function(event) {
-        if (event.name === 'popupMenu.trigger') {
-          const { data } = event;
-          expect(data.entryId).to.eql('replace-with-none-intermediate-throwing');
-          expect(data.entryGroup).to.eql('default');
-          expect(data.entryLabel).to.eql('Intermediate Throw Event');
-          expect(data.triggerType).to.eql('click');
-        }
+        expect(event).to.jsonEqual({
+          name: 'popupMenu.trigger',
+          data: {
+            entryId: 'replace-with-none-intermediate-throwing',
+            entryGroup: 'default',
+            entryLabel: 'Intermediate Throw Event',
+            triggerType: 'click'
+          },
+          type: 'tracking.event'
+        });
       });
 
+      triggerContextPad(shape, 'replace', 'click');
       bpmnJSTracking.on('tracking.event', spy);
 
       // when
-      triggerContextPad(shape, 'replace', 'click');
       triggerPopupMenu('replace-with-none-intermediate-throwing', 'click');
 
       // then
-      expect(spy).to.have.been.called;
-      expect(spy.getCalls()[1].args[1].name).to.eql('popupMenu.trigger');
+      expect(spy).to.have.been.calledOnce;
     }));
 
   });

--- a/test/spec/features/SelectionTracking.spec.js
+++ b/test/spec/features/SelectionTracking.spec.js
@@ -35,10 +35,14 @@ describe('SelectionTracking', function() {
     const newSelection = elementRegistry.get('StartEvent_1');
 
     const spy = sinon.spy(function(event) {
-      const { name, data } = event;
-      expect(name).to.eql('selection.select');
-      expect(data.newSelection).to.eql([ newSelection ]);
-      expect(data.oldSelection).to.eql([]);
+      expect(event).to.jsonEqual({
+        name: 'selection.select',
+        data: {
+          oldSelection: [],
+          newSelection: [ newSelection ]
+        },
+        type: 'tracking.event'
+      });
     });
 
     bpmnJSTracking.on('tracking.event', spy);


### PR DESCRIPTION
* Favours `calledOnce` instead of `called`
* Compares arguments within spy function using `compareEvents` utility