### PR TITLE
feat: limit element data in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [@bpmn-io/bpmn-js-tracking](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: do not track process meta-data
+
+### Breaking changes
+
+* Only a limited set of properties from elements are submitted to the tracking backend. This ensures no sensitive information is submitted.
+
 ## 0.4.0
 
 * `FEAT`: track popup menu usage

--- a/lib/BpmnJSTracking.js
+++ b/lib/BpmnJSTracking.js
@@ -34,7 +34,7 @@ class BpmnJSTracking {
 
   track(event) {
     if (this.isEnabled()) {
-      this._eventBus.fire('tracking.event', event);
+      this._eventBus.fire('tracking.event', sanitizeEvent(event));
     }
   }
 }
@@ -47,3 +47,41 @@ export default {
   ],
   bpmnJSTracking: [ 'type', BpmnJSTracking ]
 };
+
+
+// helpers //////////////////////
+
+export function sanitizeEvent(event) {
+  if (!event.data) {
+    event.data = {};
+  }
+
+  for (const [ key, value ] of Object.entries(event.data)) {
+    if (Array.isArray(value)) {
+      event.data[key] = value.map(sanitizeValue);
+    } else {
+      event.data[key] = sanitizeValue(value);
+    }
+  }
+
+  return event;
+}
+
+function sanitizeValue(value) {
+  if (!isElement(value)) {
+    return value;
+  }
+
+  return {
+    type: value.type || value.$type,
+    collapsed: value.collapsed,
+    attachers: value.attachers && value.attachers.map(sanitizeValue),
+    incoming: value.incoming && value.incoming.map(sanitizeValue),
+    outgoing: value.outgoing && value.outgoing.map(sanitizeValue),
+    parent: value.parent && sanitizeValue(value.parent)
+  };
+}
+
+function isElement(value) {
+  return value && (value.$type || value.type);
+}

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -12,14 +12,16 @@ import semver from 'semver';
 
 import TestContainer from 'mocha-test-container-support';
 
+import { sanitizeEvent } from '../lib/BpmnJSTracking';
+
 let PROPERTIES_PANEL_CONTAINER;
 
 global.chai.use(function(chai, utils) {
 
-  utils.addMethod(chai.Assertion.prototype, 'jsonEqual', function(comparison) {
+  utils.addMethod(chai.Assertion.prototype, 'eventEqual', function(comparison) {
 
     var actual = JSON.stringify(this._obj);
-    var expected = JSON.stringify(comparison);
+    var expected = JSON.stringify(sanitizeEvent(comparison));
 
     this.assert(
       actual == expected,

--- a/test/spec/BpmnJSTracking.spec.js
+++ b/test/spec/BpmnJSTracking.spec.js
@@ -140,6 +140,33 @@ describe('BpmnJSTracking', function() {
 
     }));
 
+
+    it('should strip PII data', inject(function(elementRegistry, eventBus) {
+      const trackingSpy = sinon.spy(function(event) {
+        expect(event.data.myCustomPayload.businessObject?.name).not.to.exist;
+        expect(event.data.myCustomPayload.id).not.to.exist;
+      });
+
+      eventBus.on('tracking.event', trackingSpy);
+
+      const element = elementRegistry.get('StartEvent_1');
+
+      // assume
+      expect(element.businessObject.name).to.eql('My very secret label');
+      expect(element.id).to.eql('StartEvent_1');
+
+      // when
+      trackingService.track({
+        data: {
+          myCustomPayload: element
+        }
+      });
+
+      // then
+      expect(trackingSpy).to.have.been.calledOnce;
+
+    }));
+
   });
 
 });

--- a/test/spec/features/ContextPadTracking.spec.js
+++ b/test/spec/features/ContextPadTracking.spec.js
@@ -58,7 +58,7 @@ describe('ContextPadTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'contextPad.trigger',
           data: {
             entryId: 'replace',
@@ -88,7 +88,7 @@ describe('ContextPadTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'contextPad.trigger',
           data: {
             entryId: 'append',

--- a/test/spec/features/ElementTemplatesTracking.spec.js
+++ b/test/spec/features/ElementTemplatesTracking.spec.js
@@ -139,7 +139,7 @@ describe('ElementTemplatesTracking', function() {
       await selectElement(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'elementTemplates.select',
           data: {
             element
@@ -166,7 +166,7 @@ describe('ElementTemplatesTracking', function() {
       await selectElement(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'elementTemplates.update',
           data: {
             element,
@@ -197,7 +197,7 @@ describe('ElementTemplatesTracking', function() {
       await selectElement(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'elementTemplates.unlink',
           data: {
             element
@@ -227,7 +227,7 @@ describe('ElementTemplatesTracking', function() {
       await selectElement(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'elementTemplates.remove',
           data: {
             element

--- a/test/spec/features/FeelPopupTracking.spec.js
+++ b/test/spec/features/FeelPopupTracking.spec.js
@@ -90,7 +90,7 @@ describe('FeelPopupTracking', function() {
 
       const openSpy = sinon.spy(
         function(event) {
-          expect(event).to.jsonEqual({
+          expect(event).to.eventEqual({
             name: 'feelPopup.opened',
             data: {
               selection: [ element ]
@@ -125,7 +125,7 @@ describe('FeelPopupTracking', function() {
 
       const closeSpy = sinon.spy(
         function(event) {
-          expect(event).to.jsonEqual({
+          expect(event).to.eventEqual({
             name: 'feelPopup.closed',
             data: {
               selection: [ element ]

--- a/test/spec/features/ModelingTracking.spec.js
+++ b/test/spec/features/ModelingTracking.spec.js
@@ -82,7 +82,7 @@ describe('ModelingTracking', function() {
 
       // then
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
+      expect(spy.getCalls()[0].args[1]).to.eventEqual({
         name: 'modeling.createElements',
         data: {
           elements
@@ -104,11 +104,12 @@ describe('ModelingTracking', function() {
 
       // then
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
+
+      expect(spy.getCalls()[0].args[1]).to.eventEqual({
         name: 'modeling.appendElement',
         data: {
-          sourceElement: source,
-          element: appendedElement
+          element: appendedElement,
+          sourceElement: source
         }
       });
     }));
@@ -127,11 +128,11 @@ describe('ModelingTracking', function() {
 
       // then
       expect(spy).to.have.been.calledOnce;
-      expect(spy.getCalls()[0].args[1]).to.eql({
+      expect(spy.getCalls()[0].args[1]).to.eventEqual({
         name: 'modeling.replaceElement',
         data: {
-          oldElement,
-          newElement
+          newElement,
+          oldElement
         }
       });
     }));

--- a/test/spec/features/PaletteTracking.spec.js
+++ b/test/spec/features/PaletteTracking.spec.js
@@ -58,7 +58,7 @@ describe('PaletteMenuTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'palette.trigger',
           data: {
             entryId: 'create.start-event',
@@ -88,7 +88,7 @@ describe('PaletteMenuTracking', function() {
       selection.select(element);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'palette.trigger',
           data: {
             entryId: 'create',

--- a/test/spec/features/PopupMenuTracking.spec.js
+++ b/test/spec/features/PopupMenuTracking.spec.js
@@ -74,7 +74,7 @@ describe('PopupMenuTracking', function() {
       selection.select(shape);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'popupMenu.open',
           data: {
             selection: [ shape ]
@@ -101,7 +101,7 @@ describe('PopupMenuTracking', function() {
       selection.select(shape);
 
       const spy = sinon.spy(function(event) {
-        expect(event).to.jsonEqual({
+        expect(event).to.eventEqual({
           name: 'popupMenu.trigger',
           data: {
             entryId: 'replace-with-none-intermediate-throwing',

--- a/test/spec/features/SelectionTracking.spec.js
+++ b/test/spec/features/SelectionTracking.spec.js
@@ -35,7 +35,7 @@ describe('SelectionTracking', function() {
     const newSelection = elementRegistry.get('StartEvent_1');
 
     const spy = sinon.spy(function(event) {
-      expect(event).to.jsonEqual({
+      expect(event).to.eventEqual({
         name: 'selection.select',
         data: {
           oldSelection: [],

--- a/test/spec/simple.bpmn
+++ b/test/spec/simple.bpmn
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1r85mmt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1r85mmt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_0a8lsga" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:startEvent id="StartEvent_1" name="My very secret label" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0a8lsga">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="161" y="122" width="73" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Ensure that no identifying data is tracked. We allow only certain values in the payload. The selection is a proposal and we can decide if we want more/less data to be tracked by default:
    - type
    - collapsed
    - attachers
    - incoming
    - outgoing
    - parent

This way, no data is accidentally added to the tracking events. If we want more detailed data, this needs to be explicitly added in the event

related to https://github.com/bpmn-io/internal-docs/issues/913
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
